### PR TITLE
fix: fix wrong git repository url

### DIFF
--- a/iOSLibs/IOHKAES/IOHKAES.podspec
+++ b/iOSLibs/IOHKAES/IOHKAES.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.license          = 'MIT'
     s.homepage         = 'https://github.com/input-output-hk/atala-prism-apollo'
     s.author           = { 'Ahmed Moussa' => 'moussa.ahmed95@gmail.com' }
-    s.source           = { :git => 'https://github.com/git@github.com:hyperledger/identus-apollo.git', :tag => s.version.to_s }
+    s.source           = { :git => 'git+https://github.com/hyperledger/identus-apollo.git', :tag => s.version.to_s }
     s.swift_version = '5.7'
     s.cocoapods_version = '>= 1.10.0'
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'

--- a/iOSLibs/IOHKCryptoKit/IOHKCryptoKit.podspec
+++ b/iOSLibs/IOHKCryptoKit/IOHKCryptoKit.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     
     s.homepage         = 'https://github.com/input-output-hk/atala-prism-apollo'
     s.author           = { 'Gonçalo Frade' => 'goncalo.frade@iohk.io' }
-    s.source           = { :git => 'https://github.com/git@github.com:hyperledger/identus-apollo.git', :tag => s.version.to_s }
+    s.source           = { :git => 'git+https://github.com/hyperledger/identus-apollo.git', :tag => s.version.to_s }
     s.swift_version = '5.7'
     s.cocoapods_version = '>= 1.10.0'
     

--- a/iOSLibs/IOHKRSA/IOHKRSA.podspec
+++ b/iOSLibs/IOHKRSA/IOHKRSA.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.license          = 'MIT'
     s.homepage         = 'https://github.com/input-output-hk/atala-prism-apollo'
     s.author           = { 'Ahmed Moussa' => 'moussa.ahmed95@gmail.com' }
-    s.source           = { :git => 'https://github.com/git@github.com:hyperledger/identus-apollo.git', :tag => s.version.to_s }
+    s.source           = { :git => 'git+https://github.com/hyperledger/identus-apollo.git', :tag => s.version.to_s }
     s.swift_version = '5.7'
     s.cocoapods_version = '>= 1.10.0'
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'

--- a/iOSLibs/IOHKSecureRandomGeneration/IOHKSecureRandomGeneration.podspec
+++ b/iOSLibs/IOHKSecureRandomGeneration/IOHKSecureRandomGeneration.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     
     s.homepage         = 'https://github.com/input-output-hk/atala-prism-apollo'
     s.author           = { 'Ahmed Moussa' => 'moussa.ahmed95@gmail.com' }
-    s.source           = { :git => 'https://github.com/git@github.com:hyperledger/identus-apollo.git', :tag => s.version.to_s }
+    s.source           = { :git => 'git+https://github.com/hyperledger/identus-apollo.git', :tag => s.version.to_s }
     s.swift_version = '5.7'
     s.cocoapods_version = '>= 1.10.0'
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/git@github.com:hyperledger/identus-apollo.git"
+    "url": "git+git+https://github.com/hyperledger/identus-apollo.git"
   },
   "author": "IOG",
   "license": "ISC",


### PR DESCRIPTION

### Description: 
Fixing some wrong urls generated on a replace.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-apollo/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
