### PR TITLE
fix: force bump to 1.3.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.3.6
+version = 1.3.7
 org.gradle.jvmargs = -Xmx3072M -Dkotlin.daemon.jvm.options="-Xmx3072M"
 kotlin.code.style = official
 android.useAndroidX = true


### PR DESCRIPTION
### Description: 
Increase version manually to 1.3.7 in Apollo to let the CI continue + release TS again.


### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-apollo/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
