### PR TITLE
fix: bump version for CI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.3.7
+version = 1.3.8
 org.gradle.jvmargs = -Xmx3072M -Dkotlin.daemon.jvm.options="-Xmx3072M"
 kotlin.code.style = official
 android.useAndroidX = true


### PR DESCRIPTION
### Description: 
Forcing the CI task to release next version for (swift and kmm).
Everything is released using a single semantic-release config and because the previous builds didn't fully finish the only way to get out of the situation is by bumping the version directly and forcing the next increase.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-apollo/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
