### PR TITLE
fix: make fixes to ed25519 sign method + improve tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - os: ubuntu-latest
             os-type: linux
-          - os: macos-13
+          - os: macos-latest
             os-type: macos
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: "Checkout the repo"
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Install autoconf, automake, libtool, rustup"
         run: |
-          brew install autoconf automake libtool rustup
+          brew install autoconf automake libtool rustup@1.27.0
 
       - name: "Install Mac ToolChain"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Install autoconf, automake, libtool, rustup"
         run: |
-          brew install autoconf automake libtool rustup@1.27.0
+          brew install autoconf automake libtool rustup
 
       - name: "Install Mac ToolChain"
         run: |

--- a/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/utils/KMMEdPrivateKey.kt
+++ b/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/utils/KMMEdPrivateKey.kt
@@ -49,7 +49,7 @@ actual class KMMEdPrivateKey(bytes: ByteArray) {
     actual fun sign(message: ByteArray): ByteArray {
         val sig = keyPair.sign(Buffer.from(message))
 
-        return sig.toHex().encodeToByteArray()
+        return sig.toBytes().toByteArray()
     }
 
     /**

--- a/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/utils/KMMEdPublicKey.kt
+++ b/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/utils/KMMEdPublicKey.kt
@@ -46,6 +46,9 @@ actual class KMMEdPublicKey(bytes: ByteArray) {
      * @return Boolean
      */
     actual fun verify(message: ByteArray, sig: ByteArray): Boolean {
-        return keyPair.verify(Buffer.from(message), sig.decodeToString())
+        return keyPair.verify(
+            Buffer.from(message),
+            sig.toHexString()
+        )
     }
 }

--- a/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/utils/external/Ellipticjs.kt
+++ b/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/utils/external/Ellipticjs.kt
@@ -279,7 +279,7 @@ open external class eddsa(name: String /* "ed25519" */) {
     open fun isPoint(param_val: Any): Boolean
     open class Signature {
         constructor(eddsa: eddsa, sig: _eddsa_Signature)
-        constructor(eddsa: eddsa, sig: String)
+        constructor(eddsa: eddsa, sig: Any)
         open fun toBytes(): Buffer
         open fun toHex(): String
     }

--- a/apollo/src/jsTest/kotlin/org/hyperledger/identus/apollo/utils/KMMEdKeyPairTests.kt
+++ b/apollo/src/jsTest/kotlin/org/hyperledger/identus/apollo/utils/KMMEdKeyPairTests.kt
@@ -2,26 +2,25 @@
 
 package org.hyperledger.identus.apollo.utils
 
-import node.buffer.Buffer
+import org.hyperledger.identus.apollo.base64.base64DecodedBytes
+import org.hyperledger.identus.apollo.base64.base64UrlDecodedBytes
+import org.hyperledger.identus.apollo.base64.base64UrlEncoded
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class KMMEdKeyPairTests {
-    private val raw = arrayOf(234, 155, 38, 115, 124, 211, 171, 185, 149, 186, 77, 255, 240, 94, 209, 65, 63, 214, 168, 213, 146, 68, 68, 196, 167, 211, 183, 80, 14, 166, 239, 217)
-    private val rawBytes = Buffer.from(raw).toByteArray()
-    private val encoded = arrayOf(54, 112, 115, 109, 99, 51, 122, 84, 113, 55, 109, 86, 117, 107, 51, 95, 56, 70, 55, 82, 81, 84, 95, 87, 113, 78, 87, 83, 82, 69, 84, 69, 112, 57, 79, 51, 85, 65, 54, 109, 55, 57, 107)
-    private val encodedBytes = Buffer.from(encoded).toByteArray()
-    private val publicRaw = arrayOf(207, 230, 188, 131, 200, 191, 223, 38, 163, 19, 244, 3, 35, 18, 5, 238, 195, 245, 155, 246, 139, 41, 51, 159, 202, 2, 46, 72, 150, 167, 68, 8)
-    private val publicRawBytes = Buffer.from(publicRaw).toByteArray()
-    private val publicEncoded = arrayOf(122, 45, 97, 56, 103, 56, 105, 95, 51, 121, 97, 106, 69, 95, 81, 68, 73, 120, 73, 70, 55, 115, 80, 49, 109, 95, 97, 76, 75, 84, 79, 102, 121, 103, 73, 117, 83, 74, 97, 110, 82, 65, 103)
-    private val publicEncodedBytes = Buffer.from(publicEncoded).toByteArray()
+     val rawMessage = "Hello".encodeToByteArray()
+     val rawSK = "M7+EvGp9vjLyx5SQ1xiKhRUN+YQ0kjx6d21WgX8P1hE".base64DecodedBytes
+     val rawSKEncoded = rawSK.base64UrlEncoded
+     val rawPk = "6kXLIS4a3UAzHm/5XTcvjCTGoAQ+yqPTT0YsM76EeuQ".base64DecodedBytes
+     val rawPKEncoded = rawPk.base64UrlEncoded
+     val rawSig = "rQHC0fmOclPBFiPVJCK_WJB0NgTAxSqpggPwRotNdncKrhgM2eECtr3j7UBTBmDdPTmpXGwQvyhTRTG8cymeBA".base64UrlDecodedBytes
 
     @Test
     fun testGenerateKeyPair() {
         val keyPair = KMMEdKeyPair.generateKeyPair()
-
         assertNotNull(keyPair)
         assertNotNull(keyPair.privateKey)
         assertNotNull(keyPair.publicKey)
@@ -29,78 +28,66 @@ class KMMEdKeyPairTests {
 
     @Test
     fun testConstructorRaw() {
-        val key = KMMEdPrivateKey(rawBytes)
-
-        assertTrue(key.raw.toByteArray() contentEquals rawBytes)
-        assertTrue(key.getEncoded().toByteArray() contentEquals encodedBytes)
+        val key = KMMEdPrivateKey(rawSK)
+        val rawKeyBytes = key.raw.toByteArray()
+        val rawKeyEncodedBytes = key.getEncoded().toByteArray().decodeToString()
+        assertTrue(rawKeyBytes contentEquals rawSK)
+        assertTrue(rawKeyEncodedBytes contentEquals rawSKEncoded)
     }
 
     @Test
     fun testConstructorEncoded() {
-        val key = KMMEdPrivateKey(encodedBytes)
-
-        assertTrue(key.raw.toByteArray() contentEquals rawBytes)
-        assertTrue(key.getEncoded().toByteArray() contentEquals encodedBytes)
+        val key = KMMEdPrivateKey(rawSKEncoded.base64UrlDecodedBytes)
+        assertTrue(key.raw.toByteArray() contentEquals rawSK)
+        assertTrue(key.getEncoded().toByteArray().decodeToString() contentEquals rawSKEncoded)
     }
 
     @Test
     fun testGetEncoded() {
-        val key = KMMEdPrivateKey(rawBytes)
-
-        assertTrue(key.getEncoded().toByteArray() contentEquals encodedBytes)
+        val key = KMMEdPrivateKey(rawSK)
+        assertTrue(key.getEncoded().toByteArray().decodeToString() contentEquals rawSKEncoded)
     }
+
 
     @Test
     fun testPublicKey() {
-        val privateKey = KMMEdPrivateKey(rawBytes)
+        val privateKey = KMMEdPrivateKey(rawSK)
         val publicKey = privateKey.publicKey()
-
-        assertTrue(publicKey.raw.toByteArray() contentEquals publicRawBytes)
-        assertTrue(publicKey.getEncoded().toByteArray() contentEquals publicEncodedBytes)
+        assertTrue(publicKey.raw.toByteArray() contentEquals rawPk)
+        assertTrue(publicKey.getEncoded().toByteArray().decodeToString() contentEquals rawPKEncoded)
     }
 
     @Test
     fun testSignMessage() {
         val keyPair = KMMEdKeyPair.generateKeyPair()
-        val message = "testing".encodeToByteArray()
-        val sig = keyPair.sign(message)
-
+        val sig = keyPair.sign(rawMessage)
         assertNotNull(sig)
     }
 
+
     @Test
     fun testSignMessageKnownValue() {
-        val privateKey = KMMEdPrivateKey(rawBytes)
-        val message = "testing".encodeToByteArray()
-        val sig = privateKey.sign(message)
-        val sigStr = Buffer.from(sig).toString()
-        val expectedBytes = byteArrayOf(67, 68, 57, 67, 68, 69, 52, 67, 49, 54, 50, 51, 65, 69, 57, 65, 51, 48, 55, 51, 69, 66, 50, 52, 49, 48, 67, 53, 53, 48, 52, 57, 53, 52, 70, 51, 57, 69, 68, 67, 68, 55, 66, 68, 57, 49, 57, 67, 54, 67, 49, 54, 67, 68, 54, 51, 52, 56, 48, 55, 50, 56, 53, 69, 66, 51, 70, 57, 69, 69, 51, 52, 52, 51, 57, 49, 66, 55, 65, 51, 55, 69, 54, 53, 53, 70, 56, 51, 49, 70, 68, 48, 57, 70, 50, 50, 52, 53, 68, 55, 66, 70, 50, 67, 48, 57, 70, 66, 69, 67, 57, 55, 55, 51, 50, 50, 49, 69, 65, 48, 52, 50, 70, 69, 69, 49, 48, 48)
-        val expectedStr = Buffer.from(expectedBytes).toString()
-
+        val privateKey = KMMEdPrivateKey(rawSK)
+        val sig = privateKey.sign(rawMessage)
         assertNotNull(sig)
-        assertTrue(expectedBytes contentEquals sig)
-        assertTrue(expectedStr contentEquals sigStr)
+        assertTrue(sig contentEquals rawSig)
     }
 
     @Test
     fun testVerifyMessage() {
         val keyPair = KMMEdKeyPair.generateKeyPair()
-        val msgHash = "testing".encodeToByteArray()
-        val sig = keyPair.sign(msgHash)
-        val verified = keyPair.verify(msgHash, sig)
-
+        val sig = keyPair.sign(rawMessage)
+        val verified = keyPair.verify(rawMessage, sig)
         assertTrue(verified)
     }
+
 
     @Test
     fun testVerifyWithAnotherKeyPairFails() {
         val keyPair = KMMEdKeyPair.generateKeyPair()
-        val msgHash = "testing".encodeToByteArray()
-        val sig = keyPair.sign(msgHash)
-
+        val sig = keyPair.sign(rawMessage)
         val wrongKeyPair = KMMEdKeyPair.generateKeyPair()
-        val verified = wrongKeyPair.verify(msgHash, sig)
-
+        val verified = wrongKeyPair.verify(rawMessage, sig)
         assertFalse(verified)
     }
 }


### PR DESCRIPTION


### Description: 
After some investigation, we are returning a hex encoded buffer with the signature in JS which causes compatibility issues across SDK and we are also improving the test coverage for ed25519 by using the same values on all platforms we test

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-apollo/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
