### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -135,7 +135,7 @@ jobs:
         run: ./gradlew koverHtmlReport koverXmlReport
 
       - name: "Upload coverage html"
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: coverage-results-${{ matrix.os-type }}.zip
           path: apollo/build/reports/kover/html
@@ -154,7 +154,7 @@ jobs:
 
       - name: "Upload the build report"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: "**/build/reports/"
           name: report-${{ matrix.os-type }}

--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -691,12 +691,12 @@ kotlin {
     if (os.isMacOsX) {
         if (tasks.findByName("iosX64Test") != null) {
             tasks.getByName<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest>("iosX64Test") {
-                device.set("iPhone 14 Plus")
+                device.set("iPhone 15 Pro Max")
             }
         }
         if (tasks.findByName("iosSimulatorArm64Test") != null) {
             tasks.getByName<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest>("iosSimulatorArm64Test") {
-                device.set("iPhone 14 Plus")
+                device.set("iPhone 15 Pro Max")
             }
         }
     }

--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -645,7 +645,11 @@ kotlin {
                 implementation("org.jetbrains.kotlin-wrappers:kotlin-node:18.11.13-pre.461")
             }
         }
-        val jsTest by getting
+        val jsTest by getting {
+            dependencies {
+                implementation(npm("url", "0.11.4"))
+            }
+        }
         val nativeMain by getting {
             dependsOn(allButJSMain)
             kotlin.srcDir(


### PR DESCRIPTION
### Description: 

actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
