### PR TITLE
fix: upgrade apollo to 6.6.1

### DIFF
--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -630,7 +630,7 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
-                implementation(npm("elliptic", "6.5.7"))
+                implementation(npm("elliptic", "6.6.1"))
                 implementation(npm("@types/elliptic", "6.4.18"))
                 implementation(npm("@noble/curves", "1.2.0"))
                 implementation(npm("@stablelib/x25519", "1.0.3"))


### PR DESCRIPTION

### Description: 
Replacing vulnerable elliptic package with latest updates, this is mainly used in the typescript SDK and we are having failed CI actions due to this.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-apollo/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
